### PR TITLE
fixing the issue that linked types are always a HalResource

### DIFF
--- a/src/hal-json-parser.ts
+++ b/src/hal-json-parser.ts
@@ -38,8 +38,8 @@ export class JSONParser {
         for (const linkKey in json._links) {
           if ("self" !== linkKey) {
             const href = this.extractURI(links[linkKey]);
-            const type =  Reflect.getMetadata("halClient:specificType", c.prototype, linkKey) || HalResource;
             const propKey = halToTs[linkKey] || linkKey;
+            const type =  Reflect.getMetadata("halClient:specificType", c.prototype, propKey) || HalResource;
             const linkResource = createResource(this.halRestClient, type, href);
             for (const propInLinkKey of Object.keys(links[linkKey])) {
               linkResource.prop(propInLinkKey, links[linkKey][propInLinkKey]);


### PR DESCRIPTION
I was at the point were I was wondering why an embedded HAL resource isn't of the type that it was declared. I debugged and found that little bug. If the HAL name and the TS name don't match, the wrong type is being used. This should fix it.