### PR TITLE
Fix named resource aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal-rest-client",
   "author": "Thomas Deblock <deblock.thomas.62@gmail.com>",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Hal rest client for typescript",
   "tags": [
     "HAL",

--- a/src/test/model/contacts.ts
+++ b/src/test/model/contacts.ts
@@ -1,6 +1,6 @@
 import { HalProperty, HalResource } from "../../";
 
-export class ContactInfos extends HalResource {
+export class Contacts extends HalResource {
   @HalProperty()
   public phone: string;
 }

--- a/src/test/model/location.ts
+++ b/src/test/model/location.ts
@@ -1,0 +1,6 @@
+import { HalProperty, HalResource } from "../../";
+
+export class Location extends HalResource {
+  @HalProperty()
+  public address: string;
+}

--- a/src/test/model/person.ts
+++ b/src/test/model/person.ts
@@ -1,6 +1,6 @@
 import { HalProperty, HalResource } from "../../";
 
-import { ContactInfos } from "./contact-infos";
+import { Contacts } from "./contacts";
 import { Location } from "./location";
 
 export class Person extends HalResource {
@@ -17,7 +17,7 @@ export class Person extends HalResource {
   public father: any;
 
   @HalProperty()
-  public contactInfos: ContactInfos;
+  public contacts: Contacts;
 
   @HalProperty("best-friend")
   public bestFriend: Person;

--- a/src/test/model/person.ts
+++ b/src/test/model/person.ts
@@ -1,6 +1,7 @@
 import { HalProperty, HalResource } from "../../";
 
 import { ContactInfos } from "./contact-infos";
+import { Location } from "./location";
 
 export class Person extends HalResource {
   @HalProperty()
@@ -20,4 +21,10 @@ export class Person extends HalResource {
 
   @HalProperty("best-friend")
   public bestFriend: Person;
+
+  @HalProperty(Location)
+  public home: Location;
+
+  @HalProperty("place-of-employment", Location)
+  public work: Location;
 }

--- a/src/test/rest-create-method.ts
+++ b/src/test/rest-create-method.ts
@@ -3,7 +3,7 @@ import { createClient, createResource, HalProperty, HalResource, resetCache } fr
 import * as nock from "nock";
 import { test } from "tape-async";
 
-import { ContactInfos } from "./model/contact-infos";
+import { Contacts } from "./model/contacts";
 
 let testNock;
 const basePath = "http://test.fr/";
@@ -33,8 +33,8 @@ function initTests() {
         },
     },
     _links : {
-      contactInfos : {
-        href : "http://test.fr/person/2/contactInfos",
+      contacts : {
+        href : "http://test.fr/person/2/contacts",
       },
       project: {
         href: "http://test.fr/project/4",
@@ -55,10 +55,10 @@ function initTests() {
     name : "Project 5",
   };
 
-  const contactInfos = {
+  const contacts = {
     _links : {
       self : {
-        href : "http://test.fr/person/2/contactInfos",
+        href : "http://test.fr/person/2/contacts",
       },
     },
     phone : "xxxxxxxxxx",
@@ -75,8 +75,8 @@ function initTests() {
     .reply(200, newBestFriend);
 
   testNock
-    .get("/person/2/contactInfos")
-    .reply(200, contactInfos);
+    .get("/person/2/contacts")
+    .reply(200, contacts);
 
   testNock
     .get("/project/5")

--- a/src/test/rest-delete-method.ts
+++ b/src/test/rest-delete-method.ts
@@ -3,7 +3,7 @@ import { createClient, createResource, HalProperty, HalResource, resetCache } fr
 import * as nock from "nock";
 import { test } from "tape-async";
 
-import { ContactInfos } from "./model/contact-infos";
+import { Contacts } from "./model/contacts";
 
 // mock list response
 function initTests() {
@@ -21,11 +21,11 @@ function initTests() {
     .reply(200, {success : "ok"});
 
   testNock
-    .delete("/person/2/contactInfos")
+    .delete("/person/2/contacts")
     .reply(200, {
       _links : {
         self : {
-          href : "http://test.fr/person/2/contactInfos",
+          href : "http://test.fr/person/2/contacts",
         },
       },
       phone : "xxxxxxxxxx",
@@ -63,21 +63,21 @@ test("delete read halResource json response", async (t) => {
   initTests();
   const client = createClient();
 
-  const resource = createResource(client, HalResource, "http://test.fr/person/2/contactInfos");
+  const resource = createResource(client, HalResource, "http://test.fr/person/2/contacts");
   const result = await client.delete(resource);
 
   t.equals(result.prop("phone"), "xxxxxxxxxx");
-  t.equals(result.uri.uri, "http://test.fr/person/2/contactInfos");
+  t.equals(result.uri.uri, "http://test.fr/person/2/contacts");
 });
 
 test("delete read model class json response", async (t) => {
   initTests();
   const client = createClient();
-  
-  const resource = createResource(client, ContactInfos, "http://test.fr/person/2/contactInfos");
+
+  const resource = createResource(client, Contacts, "http://test.fr/person/2/contacts");
   const result = await resource.delete();
 
-  t.ok(result instanceof ContactInfos, "result is a ContactInfos");
+  t.ok(result instanceof Contacts, "result is a contacts");
   t.equals(result.phone, "xxxxxxxxxx");
-  t.equals(result.uri.uri, "http://test.fr/person/2/contactInfos");
+  t.equals(result.uri.uri, "http://test.fr/person/2/contacts");
 });

--- a/src/test/rest-update-method.ts
+++ b/src/test/rest-update-method.ts
@@ -3,7 +3,7 @@ import { createClient, createResource, HalProperty, HalResource, resetCache } fr
 import * as nock from "nock";
 import { test } from "tape-async";
 
-import { ContactInfos } from "./model/contact-infos";
+import { Contacts } from "./model/contacts";
 
 let testNock;
 const basePath = "http://test.fr/";
@@ -33,8 +33,8 @@ function initTests() {
         },
     },
     _links : {
-      contactInfos : {
-        href : "http://test.fr/person/2/contactInfos",
+      contacts : {
+        href : "http://test.fr/person/2/contacts",
       },
       project: {
         href: "http://test.fr/project/4",
@@ -55,10 +55,10 @@ function initTests() {
     name : "Project 5",
   };
 
-  const contactInfos = {
+  const contacts = {
     _links : {
       self : {
-        href : "http://test.fr/person/2/contactInfos",
+        href : "http://test.fr/person/2/contacts",
       },
     },
     phone : "xxxxxxxxxx",
@@ -75,8 +75,8 @@ function initTests() {
     .reply(200, newBestFriend);
 
   testNock
-    .get("/person/2/contactInfos")
-    .reply(200, contactInfos);
+    .get("/person/2/contacts")
+    .reply(200, contacts);
 
   testNock
     .get("/project/5")
@@ -111,18 +111,18 @@ test("can update link using HalResource", async (t) => {
 
   const resource = await client.fetchResource("http://test.fr/person/1");
   resource.prop("name", "test");
-  await resource.prop("contactInfos").fetch();
-  resource.prop("contactInfos").prop("phone", "06XX1245XX");
+  await resource.prop("contacts").fetch();
+  resource.prop("contacts").prop("phone", "06XX1245XX");
 
   const scope = nock(basePath)
     .intercept("/person/1", "PATCH", {name: "test"})
     .reply(200);
   scope
-    .intercept("/person/2/contactInfos", "PATCH", {phone: "06XX1245XX"})
+    .intercept("/person/2/contacts", "PATCH", {phone: "06XX1245XX"})
     .reply(200);
 
   try {
-    const [result, result2] = await Promise.all([resource.update(), resource.prop("contactInfos").update()]);
+    const [result, result2] = await Promise.all([resource.update(), resource.prop("contacts").update()]);
     t.equals(result.status, 200);
     t.equals(result2.status, 200);
   } catch (e) {

--- a/src/test/test-resource-class.ts
+++ b/src/test/test-resource-class.ts
@@ -3,7 +3,7 @@ import { createClient, createResource, HalProperty, HalResource, resetCache } fr
 import * as nock from "nock";
 import { test } from "tape-async";
 
-import { ContactInfos } from "./model/contact-infos";
+import { Contacts } from "./model/contacts";
 import { Cyclical, CyclicalList } from "./model/cyclical";
 import { Location } from "./model/location";
 import { Person } from "./model/person";
@@ -47,8 +47,8 @@ function initTests() {
         ],
     },
     _links : {
-      contactInfos : {
-        href : "http://test.fr/person/2/contactInfos",
+      contacts : {
+        href : "http://test.fr/person/2/contacts",
       },
       "home" : {
         href : "http://test.fr/person/1/location/home",
@@ -63,10 +63,10 @@ function initTests() {
     name : "Project 1",
   };
 
-  const contactInfos = {
+  const contacts = {
     _links : {
       self : {
-        href : "http://test.fr/person/2/contactInfos",
+        href : "http://test.fr/person/2/contacts",
       },
     },
     phone : "xxxxxxxxxx",
@@ -100,8 +100,8 @@ function initTests() {
       .reply(200, person1);
 
   testNock
-    .get("/person/2/contactInfos")
-    .reply(200, contactInfos);
+    .get("/person/2/contacts")
+    .reply(200, contacts);
   testNock
     .get("/person/1/location/home")
     .reply(200, home);
@@ -176,11 +176,11 @@ test("can get single string prop", async (t) => {
   }
 
   // contacts
-  t.equals(person.contactInfos.phone, undefined);
-  const contactInfos = await person.contactInfos.fetch();
-  t.equals(person.contactInfos.phone, "xxxxxxxxxx");
-  t.ok(contactInfos instanceof ContactInfos);
-  t.equals(contactInfos.phone, "xxxxxxxxxx");
+  t.equals(person.contacts.phone, undefined);
+  const contacts = await person.contacts.fetch();
+  t.equals(person.contacts.phone, "xxxxxxxxxx");
+  t.ok(contacts instanceof Contacts);
+  t.equals(contacts.phone, "xxxxxxxxxx");
 
   // home
   t.equals(person.home.address, undefined);
@@ -218,7 +218,7 @@ test("fetch bad hal resource throw exception", async (t) => {
   initTests();
   const client = createClient("http://test.fr/");
   try {
-    await client.fetchArray("/person/2/contactInfos", ContactInfos);
+    await client.fetchArray("/person/2/contacts", Contacts);
     t.ko("no error throwed");
   } catch (e) {
     t.equals(e.message, "unparsable array. it's neither an array nor an halResource");
@@ -290,9 +290,9 @@ test("can set object property", async (t) => {
   t.equals(person.name, "Project 1");
   person.name = "test";
   t.equals(person.name, "test");
-  const contactInfos = createResource(client, ContactInfos, "/contacInfos/3");
-  person.contactInfos = contactInfos;
-  t.equals(person.contactInfos, contactInfos);
+  const contacts = createResource(client, Contacts, "/contacInfos/3");
+  person.contacts = contacts;
+  t.equals(person.contacts, contacts);
 });
 
 test("cyclical property have good class type", async (t) => {


### PR DESCRIPTION
It seems that property decorators fail when used with linked resources, which both rename (alias) and request a custom resource class.

This PR fixes that by adding additional metadata.

I've added new tests which check this.

To check by disabling the new functionality, comment out line 56 in `hal-decorator.ts` and run the tests again:

- https://github.com/davestewart/hal-rest-client/blob/named-aliases/src/hal-decorator.ts#L56

I also renamed `contactInfos` in the tests as we generally say `contacts` in English, and it's less to read and write!