### PR TITLE
Fix privacy of hal-rest-client.ts props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal-rest-client",
   "author": "Thomas Deblock <deblock.thomas.62@gmail.com>",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Hal rest client for typescript",
   "tags": [
     "HAL",

--- a/src/hal-rest-client.ts
+++ b/src/hal-rest-client.ts
@@ -26,8 +26,8 @@ import { IHalResource, IHalResourceConstructor} from "./hal-resource-interface";
  * ```
  */
 export class HalRestClient {
-  private axios: AxiosInstance;
-  private jsonPaser;
+  protected axios: AxiosInstance;
+  protected jsonPaser;
 
   constructor(private baseURL ?: string, options: AxiosRequestConfig = {}) {
     const config = options;


### PR DESCRIPTION
right now HalRestClient has private properties. It cannot be easily extended